### PR TITLE
Use custom cache dir for tokenizer download, too

### DIFF
--- a/tests/test_wordllama.py
+++ b/tests/test_wordllama.py
@@ -101,7 +101,7 @@ class TestWordLlama(unittest.TestCase):
             cache_dir=Path("/dummy/cache"),
         )
         self.assertEqual(
-            weights_file_path, Path("/dummy/cache/l2_supercat_256.safetensors")
+            weights_file_path, Path("/dummy/cache/weights/l2_supercat_256.safetensors")
         )
 
     @patch(
@@ -181,7 +181,9 @@ class TestWordLlama(unittest.TestCase):
             disable_download=False,
         )
         mock_check_tokenizer.assert_called_once_with(
-            config_name="l2_supercat", disable_download=False
+            config_name="l2_supercat", 
+            cache_dir=Path('/dummy/cache'), 
+            disable_download=False,
         )
         mock_load_tokenizer.assert_called_once()
         mock_safe_open.assert_called_once_with(


### PR DESCRIPTION
Presently, passing `cache_dir: Path` to `WordLlama.load()` has no impact on the cache directory where tokenizer assets are stored. This makes it impossible to use `WordLlama` in an environment where the default cache path (the user's home directory) is not writable, which is often the case in production scenarios.

This PR does two things:

- Modifies the meaning of `cache_dir` parameter on the `WordLlama.load()` method to be the cache root directory, within which the `tokenizers` and `weights` subdirectories are created;
- Ensures that the `cache_dir` is passed to `check_and_download_tokenizer` and used, so that all writes occur within a configurable cache directory;

Note that this will effectively bust the cache on upgrade. But I'm hoping that's a small price to pay for the fix.